### PR TITLE
Do no install the laster version of Cliquet for postgresql and monitoring dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,12 @@ def read_file(filename):
 
 README = read_file('README.rst')
 REQUIREMENTS = [
-    "cliquet[monitoring,postgresql]",
+    "SQLAlchemy",
+    "psycopg2>2.5"
+    "zope.sqlalchemy",
+    "raven",
+    "statsd"
+    "newrelic",
     "kinto",
     "kinto-attachment",
     "kinto-changes",


### PR DESCRIPTION
This can lead to this kind of errors:

```
pkg_resources.VersionConflict: (cliquet 3.1.0 (/data/kinto/lib/python2.7/site-packages), Requirement.parse('cliquet>=2.15,<3'))
```

r? @leplatrem